### PR TITLE
Fix output files and parameter ids in the success criteria

### DIFF
--- a/ansys/rep/client/jms/schema/task_definition.py
+++ b/ansys/rep/client/jms/schema/task_definition.py
@@ -56,7 +56,7 @@ class SuccessCriteriaSchema(BaseSchema):
         fields.String(), allow_none=True, description="A list of expressions to be evaluated."
     )
 
-    required_output_files = IdReferenceList(
+    required_output_file_ids = IdReferenceList(
         "File",
         attribute="required_output_file_ids",
         allow_none=True,
@@ -66,7 +66,7 @@ class SuccessCriteriaSchema(BaseSchema):
         allow_none=True, description="Flag to require all output files."
     )
 
-    required_output_parameters = IdReferenceList(
+    required_output_parameter_ids = IdReferenceList(
         "ParameterDefinition",
         attribute="required_output_parameter_ids",
         allow_none=True,

--- a/tests/jms/test_task_definition.py
+++ b/tests/jms/test_task_definition.py
@@ -176,6 +176,8 @@ class TaskDefinitionTest(REPTestCase):
                 expressions=[],
                 require_all_output_files=False,
                 require_all_output_parameters=True,
+                required_output_file_ids=["id1", "id2"],
+                required_output_parameter_ids=["id3", "id4"],
                 return_code=0,
             ),
             use_execution_script=False,
@@ -213,13 +215,15 @@ class TaskDefinitionTest(REPTestCase):
                 "FAKE_FILE_ID",
             ],
         )
-        self.assertEqual(
+        self.assertDictEqual(
             serialized_task_def["success_criteria"],
             OrderedDict(
                 {
                     "return_code": 0,
                     "expressions": [],
+                    "required_output_file_ids": ["id1", "id2"],
                     "require_all_output_files": False,
+                    "required_output_parameter_ids": ["id3", "id4"],
                     "require_all_output_parameters": True,
                 }
             ),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -23,6 +23,8 @@ class REPClientTest(REPTestCase):
         project_api = ProjectApi(self.client, project.id)
 
         self.assertEqual(len(project_api.get_jobs()), num_jobs)
+        td = project_api.get_task_definitions()[0]
+        self.assertEqual(len(td.success_criteria.required_output_file_ids), 1)
 
         jms_api.delete_project(project)
 


### PR DESCRIPTION
## Description

As reported by Quanqing Yan (Ansys Forming), output files and parameter ids in the success criteria were silently ignored and not sent through the REST API.

## Checklist
Please complete the following checklist before submitting your pull request:
- [x] I have tested these changes locally and verified that they work as intended.
- [x] I have updated any documentation as needed to reflect these changes (if appropriate)
- [x] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
- [x] Unit tests have been added (if appropriate)
- [x] Test-cases have been added (if appropriate)
- [x] Testing instructions have been added (if appropriate)
