### PR TITLE
Remove unnecessary files from wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(
         "backoff>=2.0.0",
     ],
     python_requires=">=3.7",
-    packages=find_namespace_packages(where=".", include="ansys*"),
+    packages=find_namespace_packages(include=["ansys.*"]),
 )


### PR DESCRIPTION
## Description

Because of some wrong settings in setup.py, the pyrep wheel contains extra files that should not be there
![image](https://github.com/ansys-internal/pyrep/assets/11756875/f17062a1-9d5b-4960-94a8-aacca1c0ff52)
Only the last two folders are needed.

Build with new wheel https://github.com/ansys-internal/pyrep/actions/runs/6743607013

## Checklist
Please complete the following checklist before submitting your pull request:
- [x] I have tested these changes locally and verified that they work as intended.
- [x] I have updated any documentation as needed to reflect these changes (if appropriate)
- [x] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
- [x] Unit tests have been added (if appropriate)
- [x] Test-cases have been added (if appropriate)
- [x] Testing instructions have been added (if appropriate)
