### PR TITLE
Fix download of file when the evaluation path contains a subdir

### DIFF
--- a/ansys/rep/client/jms/api/project_api.py
+++ b/ansys/rep/client/jms/api/project_api.py
@@ -577,9 +577,9 @@ def _download_file(
     if getattr(file, "hash", None) is None:
         log.warning(f"No hash found for file {file.name}.")
 
-    Path(target_path).mkdir(parents=True, exist_ok=True)
     download_link = f"{project_api.fs_bucket_url}/{file.storage_id}"
     download_path = os.path.join(target_path, file.evaluation_path)
+    Path(download_path).parent.mkdir(parents=True, exist_ok=True)
 
     with project_api.client.session.get(download_link, stream=stream) as r, open(
         download_path, "wb"

--- a/tests/jms/test_files.py
+++ b/tests/jms/test_files.py
@@ -119,6 +119,34 @@ class FilesTest(REPTestCase):
         # Delete project again
         jms_api.delete_project(proj)
 
+    def test_download_file_in_subdir(self):
+
+        client = self.client
+        jms_api = JmsApi(client)
+        proj = jms_api.create_project(
+            Project(name=f"rep_test_download_file_in_subdir", active=False)
+        )
+        project_api = ProjectApi(client, proj.id)
+
+        files = [
+            File(
+                name="file",
+                evaluation_path="subdir/file.txt",
+                type="text/plain",
+                src=io.BytesIO(b"This is my file"),
+            )
+        ]
+
+        file = project_api.create_files(files)[0]
+
+        with tempfile.TemporaryDirectory() as tpath:
+            fpath = project_api.download_file(file, tpath)
+            with open(fpath, "r") as sf:
+                self.assertEqual("This is my file", sf.read())
+
+        # Delete project again
+        jms_api.delete_project(proj)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

As reported by Yan (Ansys Forming): downloading a file with evaluation path containing a sub directory (like `B-05\B-05.d3plot`) was failing. Fixed by properly creating the target directory.

## Checklist
Please complete the following checklist before submitting your pull request:
- [x] I have tested these changes locally and verified that they work as intended.
- [x] I have updated any documentation as needed to reflect these changes (if appropriate)
- [x] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
- [x] Unit tests have been added (if appropriate)
- [x] Test-cases have been added (if appropriate)
- [x] Testing instructions have been added (if appropriate)
