### PR TITLE
Improve type checking for create, update and delete methods

### DIFF
--- a/ansys/hps/client/jms/api/jms_api.py
+++ b/ansys/hps/client/jms/api/jms_api.py
@@ -129,7 +129,14 @@ class JmsApi(object):
             templates (list of :class:`ansys.hps.client.jms.TaskDefinitionTemplate`):
                 A list of task definition templates
         """
-        return create_objects(self.client.session, self.url, templates, as_objects, **query_params)
+        return create_objects(
+            self.client.session,
+            self.url,
+            templates,
+            TaskDefinitionTemplate,
+            as_objects,
+            **query_params,
+        )
 
     def update_task_definition_templates(
         self, templates: List[TaskDefinitionTemplate], as_objects=True, **query_params
@@ -156,7 +163,7 @@ class JmsApi(object):
             templates (list of :class:`ansys.hps.client.jms.TaskDefinitionTemplate`):
                 A list of task definition templates
         """
-        return delete_objects(self.client.session, self.url, templates)
+        return delete_objects(self.client.session, self.url, templates, TaskDefinitionTemplate)
 
     def copy_task_definition_templates(
         self, templates: List[TaskDefinitionTemplate], wait: bool = True

--- a/ansys/hps/client/jms/api/project_api.py
+++ b/ansys/hps/client/jms/api/project_api.py
@@ -139,7 +139,7 @@ class ProjectApi:
         return update_files(self, files, as_objects=as_objects)
 
     def delete_files(self, files: List[File]):
-        return self._delete_objects(files)
+        return self._delete_objects(files, File)
 
     def download_file(
         self,
@@ -163,9 +163,9 @@ class ProjectApi:
         return self._get_objects(ParameterDefinition, as_objects, **query_params)
 
     def create_parameter_definitions(
-        self, parameter_definitions, as_objects=True
+        self, parameter_definitions: List[ParameterDefinition], as_objects=True
     ) -> List[ParameterDefinition]:
-        return self._create_objects(parameter_definitions, as_objects)
+        return self._create_objects(parameter_definitions, ParameterDefinition, as_objects)
 
     def update_parameter_definitions(
         self, parameter_definitions: List[ParameterDefinition], as_objects=True
@@ -173,7 +173,7 @@ class ProjectApi:
         return self._update_objects(parameter_definitions, ParameterDefinition, as_objects)
 
     def delete_parameter_definitions(self, parameter_definitions: List[ParameterDefinition]):
-        return self._delete_objects(parameter_definitions)
+        return self._delete_objects(parameter_definitions, ParameterDefinition)
 
     ################################################################
     # Parameter mappings
@@ -183,7 +183,7 @@ class ProjectApi:
     def create_parameter_mappings(
         self, parameter_mappings: List[ParameterMapping], as_objects=True
     ) -> List[ParameterMapping]:
-        return self._create_objects(parameter_mappings, as_objects=as_objects)
+        return self._create_objects(parameter_mappings, ParameterMapping, as_objects=as_objects)
 
     def update_parameter_mappings(
         self, parameter_mappings: List[ParameterMapping], as_objects=True
@@ -191,7 +191,7 @@ class ProjectApi:
         return self._update_objects(parameter_mappings, ParameterMapping, as_objects=as_objects)
 
     def delete_parameter_mappings(self, parameter_mappings: List[ParameterMapping]):
-        return self._delete_objects(parameter_mappings)
+        return self._delete_objects(parameter_mappings, ParameterMapping)
 
     ################################################################
     # Task definitions
@@ -201,7 +201,7 @@ class ProjectApi:
     def create_task_definitions(
         self, task_definitions: List[TaskDefinition], as_objects=True
     ) -> List[TaskDefinition]:
-        return self._create_objects(task_definitions, as_objects=as_objects)
+        return self._create_objects(task_definitions, TaskDefinition, as_objects=as_objects)
 
     def update_task_definitions(
         self, task_definitions: List[TaskDefinition], as_objects=True
@@ -209,7 +209,7 @@ class ProjectApi:
         return self._update_objects(task_definitions, TaskDefinition, as_objects=as_objects)
 
     def delete_task_definitions(self, task_definitions: List[TaskDefinition]):
-        return self._delete_objects(task_definitions)
+        return self._delete_objects(task_definitions, TaskDefinition)
 
     def copy_task_definitions(
         self, task_definitions: List[TaskDefinition], wait: bool = True
@@ -242,7 +242,7 @@ class ProjectApi:
     def create_job_definitions(
         self, job_definitions: List[JobDefinition], as_objects=True
     ) -> List[JobDefinition]:
-        return self._create_objects(job_definitions, as_objects=as_objects)
+        return self._create_objects(job_definitions, JobDefinition, as_objects=as_objects)
 
     def update_job_definitions(
         self, job_definitions: List[JobDefinition], as_objects=True
@@ -250,7 +250,7 @@ class ProjectApi:
         return self._update_objects(job_definitions, JobDefinition, as_objects=as_objects)
 
     def delete_job_definitions(self, job_definitions: List[JobDefinition]):
-        return self._delete_objects(job_definitions)
+        return self._delete_objects(job_definitions, JobDefinition)
 
     def copy_job_definitions(
         self, job_definitions: List[JobDefinition], wait: bool = True
@@ -290,7 +290,7 @@ class ProjectApi:
         Returns:
             List of :class:`ansys.hps.client.jms.Job` or list of dict if `as_objects` is False
         """
-        return self._create_objects(jobs, as_objects=as_objects)
+        return self._create_objects(jobs, Job, as_objects=as_objects)
 
     def copy_jobs(self, jobs: List[Job], wait: bool = True) -> Union[str, List[str]]:
         """Create new jobs by copying existing ones
@@ -342,7 +342,7 @@ class ProjectApi:
             >>> project_api.delete_jobs(jobs_to_delete)
 
         """
-        return self._delete_objects(jobs)
+        return self._delete_objects(jobs, Job)
 
     def sync_jobs(self, jobs: List[Job]):
         return sync_jobs(self, jobs)
@@ -372,7 +372,7 @@ class ProjectApi:
     def create_job_selections(
         self, selections: List[JobSelection], as_objects=True
     ) -> List[JobSelection]:
-        return self._create_objects(selections, as_objects=as_objects)
+        return self._create_objects(selections, JobSelection, as_objects=as_objects)
 
     def update_job_selections(
         self, selections: List[JobSelection], as_objects=True
@@ -380,7 +380,7 @@ class ProjectApi:
         return self._update_objects(selections, JobSelection, as_objects=as_objects)
 
     def delete_job_selections(self, selections: List[JobSelection]):
-        return self._delete_objects(selections)
+        return self._delete_objects(selections, JobSelection)
 
     ################################################################
     # Algorithms
@@ -388,13 +388,13 @@ class ProjectApi:
         return self._get_objects(Algorithm, as_objects=as_objects, **query_params)
 
     def create_algorithms(self, algorithms: List[Algorithm], as_objects=True) -> List[Algorithm]:
-        return self._create_objects(algorithms, as_objects=as_objects)
+        return self._create_objects(algorithms, Algorithm, as_objects=as_objects)
 
     def update_algorithms(self, algorithms: List[Algorithm], as_objects=True) -> List[Algorithm]:
         return self._update_objects(algorithms, Algorithm, as_objects=as_objects)
 
     def delete_algorithms(self, algorithms: List[Algorithm]):
-        return self._delete_objects(algorithms)
+        return self._delete_objects(algorithms, Algorithm)
 
     ################################################################
     # Permissions
@@ -466,8 +466,12 @@ class ProjectApi:
     def _get_objects(self, obj_type: Object, as_objects=True, **query_params):
         return get_objects(self.client.session, self.url, obj_type, as_objects, **query_params)
 
-    def _create_objects(self, objects: List[Object], as_objects=True, **query_params):
-        return create_objects(self.client.session, self.url, objects, as_objects, **query_params)
+    def _create_objects(
+        self, objects: List[Object], obj_type: Type[Object], as_objects=True, **query_params
+    ):
+        return create_objects(
+            self.client.session, self.url, objects, obj_type, as_objects, **query_params
+        )
 
     def _update_objects(
         self, objects: List[Object], obj_type: Type[Object], as_objects=True, **query_params
@@ -476,8 +480,8 @@ class ProjectApi:
             self.client.session, self.url, objects, obj_type, as_objects, **query_params
         )
 
-    def _delete_objects(self, objects: List[Object]):
-        delete_objects(self.client.session, self.url, objects)
+    def _delete_objects(self, objects: List[Object], obj_type: Type[Object]):
+        delete_objects(self.client.session, self.url, objects, obj_type)
 
 
 def _download_files(project_api: ProjectApi, files: List[File]):
@@ -534,7 +538,7 @@ def _upload_files(project_api: ProjectApi, files):
 def create_files(project_api: ProjectApi, files, as_objects=True) -> List[File]:
     # (1) Create file resources in JMS
     created_files = create_objects(
-        project_api.client.session, project_api.url, files, as_objects=as_objects
+        project_api.client.session, project_api.url, files, File, as_objects=as_objects
     )
 
     # (2) Check if there are src properties, files to upload

--- a/ansys/hps/client/rms/api/base.py
+++ b/ansys/hps/client/rms/api/base.py
@@ -142,8 +142,8 @@ def update_objects(
     **query_params,
 ):
 
-    if objects is None:
-        raise ClientError("objects can't be None")
+    if not objects:
+        return []
 
     are_same = [o.__class__ == obj_type for o in objects]
     if not all(are_same):

--- a/tests/jms/test_jms_api.py
+++ b/tests/jms/test_jms_api.py
@@ -11,9 +11,15 @@ import unittest
 from examples.mapdl_motorbike_frame.project_setup import create_project
 from marshmallow.utils import missing
 
-from ansys.hps.client import Client
+from ansys.hps.client import Client, ClientError
 from ansys.hps.client.jms import JmsApi, ProjectApi
-from ansys.hps.client.jms.resource import Job, Project
+from ansys.hps.client.jms.resource import (
+    FloatParameterDefinition,
+    IntParameterDefinition,
+    Job,
+    JobDefinition,
+    Project,
+)
 from tests.rep_test import REPTestCase
 
 log = logging.getLogger(__name__)
@@ -129,6 +135,62 @@ class REPClientTest(REPTestCase):
             self.assertTrue("name" in storage)
             self.assertTrue("priority" in storage)
             self.assertTrue("obj_type" in storage)
+
+    def test_objects_type_check(self):
+
+        proj_name = f"test_objects_type_check"
+
+        client = self.client
+
+        proj = Project(name=proj_name, active=True)
+        job_def = JobDefinition(name="Job Def", active=True)
+        job = Job(name="test")
+
+        jms_api = JmsApi(client)
+
+        with self.assertRaises(ClientError) as context:
+            _ = jms_api.create_task_definition_templates([job])
+        assert "Wrong object type" in str(context.exception)
+        assert "got <class 'ansys.hps.client.jms.resource.job.Job'>" in str(context.exception)
+
+        proj = jms_api.create_project(proj, replace=True)
+        project_api = ProjectApi(client, proj.id)
+
+        job_def = JobDefinition(name="New Config", active=True)
+
+        with self.assertRaises(ClientError) as context:
+            _ = project_api.create_jobs([job_def])
+        assert "Wrong object type" in str(context.exception)
+        assert "got <class 'ansys.hps.client.jms.resource.job_definition.JobDefinition'>" in str(
+            context.exception
+        )
+
+        job_def = project_api.create_job_definitions([job_def])[0]
+
+        # verify support for mixed parameter definitions
+        with self.assertRaises(ClientError) as context:
+            _ = project_api.create_parameter_definitions(
+                [
+                    FloatParameterDefinition(),
+                    Job(),
+                ]
+            )
+        msg = str(context.exception)
+        assert "Wrong object type" in msg
+        assert "<class 'ansys.hps.client.jms.resource.job.Job'>" in msg
+        assert (
+            "<class 'ansys.hps.client.jms.resource.parameter_definition.FloatParameterDefinition'>"
+            in msg
+        )
+
+        _ = project_api.create_parameter_definitions(
+            [
+                FloatParameterDefinition(),
+                IntParameterDefinition(),
+            ]
+        )
+
+        JmsApi(client).delete_project(proj)
 
 
 if __name__ == "__main__":

--- a/tests/jms/test_parameter_definitions.py
+++ b/tests/jms/test_parameter_definitions.py
@@ -200,13 +200,33 @@ class ParameterDefitionTest(REPTestCase):
         self.assertTrue(fp.id in job_def.parameter_definition_ids)
         self.assertTrue(bp.id in job_def.parameter_definition_ids)
 
-        # job_def.parameter_definitions[2].upper_limit = 13.0
-        # job_def.parameter_definitions[2].lower_limit = 4.5
-        # job_def = proj.update_job_definitions([job_def])[0]
-        # job_def = proj.get_job_definitions([job_def])[0]
-        # self.assertEqual(len(job_def.parameter_definitions), 4)
-        # self.assertEqual(job_def.parameter_definitions[2].upper_limit, 13.0)
-        # self.assertEqual(job_def.parameter_definitions[2].lower_limit, 4.5)
+        # Delete project
+        jms_api.delete_project(proj)
+
+    def test_mixed_parameter_definition(self):
+
+        client = self.client
+        proj_name = f"test_mixed_parameter_definition"
+
+        proj = Project(name=proj_name, active=True)
+        jms_api = JmsApi(client)
+        proj = jms_api.create_project(proj, replace=True)
+        project_api = ProjectApi(client, proj.id)
+
+        ip = IntParameterDefinition(name="int_param", upper_limit=27)
+        sp = StringParameterDefinition(name="s_param", value_list=["l1", "l2"])
+        fp = FloatParameterDefinition(name="f_param", display_text="A Float Parameter")
+        bp = BoolParameterDefinition(name="b_param", display_text="A Bool Parameter", default=False)
+
+        original_pds = [ip, sp, fp, bp]
+        pds = project_api.create_parameter_definitions(original_pds)
+
+        for pd, original_pd in zip(pds, original_pds):
+            assert type(pd) == type(original_pd)
+            assert pd.name == original_pd.name
+
+        assert pds[0].upper_limit == 27
+        assert pds[1].value_list == ["l1", "l2"]
 
         # Delete project
         jms_api.delete_project(proj)


### PR DESCRIPTION
Wayne (EBU) was accidentally trying to create jobs by passing wrong object types (like `project_api.create_jobs([job_definition])`) and rightfully remarked that the client didn't complain about it. 

In this PR, I'm adding more static type checking to update, create and delete calls. As a byproduct, I could also remove the long-standing limitations of not being able to create parameter definitions of mixed type. 