### PR TITLE
Fix import error in python example for multi process step

### DIFF
--- a/examples/python_multi_process_step/project_setup.py
+++ b/examples/python_multi_process_step/project_setup.py
@@ -64,7 +64,7 @@ from ansys.hps.client.jms import (
     TaskDefinition,
 )
 
-from .task_files import update_task_files
+from task_files import update_task_files
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Test is failing with:
```
Traceback (most recent call last):
  File "D:\projects\ansys\devel\pyhps\examples\python_multi_process_step\project_setup.py", line 67, in <module>
    from .task_files import update_task_files
ImportError: attempted relative import with no known parent package
```
