### PR TITLE
feat: update license start year

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,8 @@ repos:
   hooks:
   - id: add-license-headers
     files: '(ansys|examples|tests)/.*\.(py)|\.(proto)|generate_resources.py|archive_examples.py'
+    args:
+    - --start_year=2022
 
 # For now we disable some of these checks, can be reenabled later
 # - repo: https://github.com/pycqa/pydocstyle

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/archive_examples.py
+++ b/archive_examples.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/authorization_grant/authorization_grant.py
+++ b/examples/authorization_grant/authorization_grant.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/cfx_static_mixer/exec_cfx.py
+++ b/examples/cfx_static_mixer/exec_cfx.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/cfx_static_mixer/project_setup.py
+++ b/examples/cfx_static_mixer/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/fluent_2d_heat_exchanger/project_setup.py
+++ b/examples/fluent_2d_heat_exchanger/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/fluent_nozzle/project_setup.py
+++ b/examples/fluent_nozzle/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/lsdyna_cylinder_plate/lsdyna_job.py
+++ b/examples/lsdyna_cylinder_plate/lsdyna_job.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/mapdl_linked_analyses/project_setup.py
+++ b/examples/mapdl_linked_analyses/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/mapdl_motorbike_frame/exec_mapdl.py
+++ b/examples/mapdl_motorbike_frame/exec_mapdl.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/mapdl_motorbike_frame/project_query.py
+++ b/examples/mapdl_motorbike_frame/project_query.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/mapdl_motorbike_frame/project_setup.py
+++ b/examples/mapdl_motorbike_frame/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/mapdl_motorbike_frame/task_files.py
+++ b/examples/mapdl_motorbike_frame/task_files.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/mapdl_tyre_performance/project_setup.py
+++ b/examples/mapdl_tyre_performance/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/python_linked_multi_process_step/eval.py
+++ b/examples/python_linked_multi_process_step/eval.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/python_linked_multi_process_step/project_setup.py
+++ b/examples/python_linked_multi_process_step/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/python_multi_process_step/eval.py
+++ b/examples/python_multi_process_step/eval.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/python_multi_process_step/project_setup.py
+++ b/examples/python_multi_process_step/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/python_multi_process_step/task_files.py
+++ b/examples/python_multi_process_step/task_files.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/python_two_bar_truss_problem/evaluate.py
+++ b/examples/python_two_bar_truss_problem/evaluate.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/python_two_bar_truss_problem/exec_python.py
+++ b/examples/python_two_bar_truss_problem/exec_python.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/python_two_bar_truss_problem/project_setup.py
+++ b/examples/python_two_bar_truss_problem/project_setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/generate_resources.py
+++ b/generate_resources.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/__init__.py
+++ b/src/ansys/hps/client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/__version__.py
+++ b/src/ansys/hps/client/__version__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/auth/__init__.py
+++ b/src/ansys/hps/client/auth/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/auth/api/__init__.py
+++ b/src/ansys/hps/client/auth/api/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/auth/api/auth_api.py
+++ b/src/ansys/hps/client/auth/api/auth_api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/auth/authenticate.py
+++ b/src/ansys/hps/client/auth/authenticate.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/auth/resource/__init__.py
+++ b/src/ansys/hps/client/auth/resource/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/auth/resource/user.py
+++ b/src/ansys/hps/client/auth/resource/user.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/auth/schema/__init__.py
+++ b/src/ansys/hps/client/auth/schema/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/auth/schema/user.py
+++ b/src/ansys/hps/client/auth/schema/user.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/common/__init__.py
+++ b/src/ansys/hps/client/common/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/common/base_resource.py
+++ b/src/ansys/hps/client/common/base_resource.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/common/base_schema.py
+++ b/src/ansys/hps/client/common/base_schema.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/common/restricted_value.py
+++ b/src/ansys/hps/client/common/restricted_value.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/connection.py
+++ b/src/ansys/hps/client/connection.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/exceptions.py
+++ b/src/ansys/hps/client/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/__init__.py
+++ b/src/ansys/hps/client/jms/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/api/__init__.py
+++ b/src/ansys/hps/client/jms/api/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/api/base.py
+++ b/src/ansys/hps/client/jms/api/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/api/jms_api.py
+++ b/src/ansys/hps/client/jms/api/jms_api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/api/project_api.py
+++ b/src/ansys/hps/client/jms/api/project_api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/keys.py
+++ b/src/ansys/hps/client/jms/keys.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/__init__.py
+++ b/src/ansys/hps/client/jms/resource/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/algorithm.py
+++ b/src/ansys/hps/client/jms/resource/algorithm.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/file.py
+++ b/src/ansys/hps/client/jms/resource/file.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/fitness_definition.py
+++ b/src/ansys/hps/client/jms/resource/fitness_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/job.py
+++ b/src/ansys/hps/client/jms/resource/job.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/job_definition.py
+++ b/src/ansys/hps/client/jms/resource/job_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/license_context.py
+++ b/src/ansys/hps/client/jms/resource/license_context.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/operation.py
+++ b/src/ansys/hps/client/jms/resource/operation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/parameter_definition.py
+++ b/src/ansys/hps/client/jms/resource/parameter_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/parameter_mapping.py
+++ b/src/ansys/hps/client/jms/resource/parameter_mapping.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/permission.py
+++ b/src/ansys/hps/client/jms/resource/permission.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/project.py
+++ b/src/ansys/hps/client/jms/resource/project.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/selection.py
+++ b/src/ansys/hps/client/jms/resource/selection.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/task.py
+++ b/src/ansys/hps/client/jms/resource/task.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/task_definition.py
+++ b/src/ansys/hps/client/jms/resource/task_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/resource/task_definition_template.py
+++ b/src/ansys/hps/client/jms/resource/task_definition_template.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/__init__.py
+++ b/src/ansys/hps/client/jms/schema/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/algorithm.py
+++ b/src/ansys/hps/client/jms/schema/algorithm.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/file.py
+++ b/src/ansys/hps/client/jms/schema/file.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/fitness_definition.py
+++ b/src/ansys/hps/client/jms/schema/fitness_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/job.py
+++ b/src/ansys/hps/client/jms/schema/job.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/job_definition.py
+++ b/src/ansys/hps/client/jms/schema/job_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/license_context.py
+++ b/src/ansys/hps/client/jms/schema/license_context.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/object_reference.py
+++ b/src/ansys/hps/client/jms/schema/object_reference.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/operation.py
+++ b/src/ansys/hps/client/jms/schema/operation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/parameter_definition.py
+++ b/src/ansys/hps/client/jms/schema/parameter_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/parameter_mapping.py
+++ b/src/ansys/hps/client/jms/schema/parameter_mapping.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/permission.py
+++ b/src/ansys/hps/client/jms/schema/permission.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/project.py
+++ b/src/ansys/hps/client/jms/schema/project.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/selection.py
+++ b/src/ansys/hps/client/jms/schema/selection.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/task.py
+++ b/src/ansys/hps/client/jms/schema/task.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/task_definition.py
+++ b/src/ansys/hps/client/jms/schema/task_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/jms/schema/task_definition_template.py
+++ b/src/ansys/hps/client/jms/schema/task_definition_template.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/rms/__init__.py
+++ b/src/ansys/hps/client/rms/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/rms/api/__init__.py
+++ b/src/ansys/hps/client/rms/api/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/rms/api/base.py
+++ b/src/ansys/hps/client/rms/api/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/rms/api/rms_api.py
+++ b/src/ansys/hps/client/rms/api/rms_api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/rms/models.py
+++ b/src/ansys/hps/client/rms/models.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/hps/client/warnings.py
+++ b/src/ansys/hps/client/warnings.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/auth/__init__.py
+++ b/tests/auth/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/auth/test_api.py
+++ b/tests/auth/test_api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/auth/test_authenticate.py
+++ b/tests/auth/test_authenticate.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/__init__.py
+++ b/tests/jms/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_algorithms.py
+++ b/tests/jms/test_algorithms.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_files.py
+++ b/tests/jms/test_files.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_fitness_definition.py
+++ b/tests/jms/test_fitness_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_jms_api.py
+++ b/tests/jms/test_jms_api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_job_definitions.py
+++ b/tests/jms/test_job_definitions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_jobs.py
+++ b/tests/jms/test_jobs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_parameter_definitions.py
+++ b/tests/jms/test_parameter_definitions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_project_permissions.py
+++ b/tests/jms/test_project_permissions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_projects.py
+++ b/tests/jms/test_projects.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_resources.py
+++ b/tests/jms/test_resources.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_task_definition.py
+++ b/tests/jms/test_task_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_task_definition_templates.py
+++ b/tests/jms/test_task_definition_templates.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_task_files.py
+++ b/tests/jms/test_task_files.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/jms/test_tasks.py
+++ b/tests/jms/test_tasks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/rms/__init__.py
+++ b/tests/rms/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/rms/test_api.py
+++ b/tests/rms/test_api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/rms/test_compute_resource_sets.py
+++ b/tests/rms/test_compute_resource_sets.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/rms/test_evaluators.py
+++ b/tests/rms/test_evaluators.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/rms/test_serialization.py
+++ b/tests/rms/test_serialization.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #


### PR DESCRIPTION
## Description
Updating start year for license headers - it should always be the starting year of the library according to git history.

