### PR TITLE
Set username based on token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "setuptools;python_version>='3.12'", # Python3.12 doesn't include setuptools automatically
     "backoff>=2.0.0",
     "pydantic>=1.10.0",
+    "PyJWT>=2.8.0"
 ]
 
 [project.optional-dependencies]

--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -192,16 +192,20 @@ class Client(object):
             )
             self.access_token = tokens["access_token"]
 
+            parsed_username = None
+
             try:
                 parsed_jwt = jwt.decode(self.access_token, options={"verify_signature": False})
-                parsed_username = parsed_jwt.get("preferred_username", None)
+                parsed_username = parsed_jwt["preferred_username"]
+            except:
+                log.warning("Could not retrieve preferred_username from access token.")
+
+            if parsed_username != None:
                 if self.username != None and self.username != parsed_username:
                     raise HPSError(
                         "Username and preferred_username from access token do not match."
                     )
                 self.username = parsed_username
-            except:
-                log.warning("Could not retrieve preferred_username from access token.")
 
             # client credentials flow does not return a refresh token
             self.refresh_token = tokens.get("refresh_token", None)

--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -25,6 +25,7 @@ import logging
 from typing import Union
 import warnings
 
+import jwt
 import requests
 
 from .auth.authenticate import authenticate
@@ -190,6 +191,13 @@ class Client(object):
                 verify=self.verify,
             )
             self.access_token = tokens["access_token"]
+
+            try:
+                parsed_jwt = jwt.decode(self.access_token, options={"verify_signature": False})
+                self.username = parsed_jwt.get("preferred_username", self.username)
+            except:
+                log.warning("Could not retrieve username from access token")
+
             # client credentials flow does not return a refresh token
             self.refresh_token = tokens.get("refresh_token", None)
 

--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -191,28 +191,27 @@ class Client(object):
                 verify=self.verify,
             )
             self.access_token = tokens["access_token"]
-
-            parsed_username = None
-
-            try:
-                parsed_jwt = jwt.decode(self.access_token, options={"verify_signature": False})
-                parsed_username = parsed_jwt["preferred_username"]
-            except:
-                log.warning("Could not retrieve 'preferred_username' from access token.")
-
-            if parsed_username != None:
-                if self.username != None and self.username != parsed_username:
-                    raise HPSError(
-                        (
-                            f"Username: '{self.username}' and "
-                            f"preferred_username: '{parsed_username}' "
-                            "from access token do not match."
-                        )
-                    )
-                self.username = parsed_username
-
             # client credentials flow does not return a refresh token
             self.refresh_token = tokens.get("refresh_token", None)
+
+        parsed_username = None
+
+        try:
+            parsed_jwt = jwt.decode(self.access_token, options={"verify_signature": False})
+            parsed_username = parsed_jwt["preferred_username"]
+        except:
+            log.warning("Could not retrieve preferred_username from access token.")
+
+        if parsed_username is not None:
+            if self.username is not None and self.username != parsed_username:
+                raise HPSError(
+                    (
+                        f"Username: '{self.username}' and "
+                        f"preferred_username: '{parsed_username}' "
+                        "from access token do not match."
+                    )
+                )
+            self.username = parsed_username
 
         self.session = create_session(
             self.access_token,

--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -203,7 +203,11 @@ class Client(object):
             if parsed_username != None:
                 if self.username != None and self.username != parsed_username:
                     raise HPSError(
-                        "Username and preferred_username from access token do not match."
+                        (
+                            f"Username: '{self.username}' and "
+                            f"preferred_username: '{parsed_username}' "
+                            "from access token do not match."
+                        )
                     )
                 self.username = parsed_username
 

--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -198,7 +198,7 @@ class Client(object):
                 parsed_jwt = jwt.decode(self.access_token, options={"verify_signature": False})
                 parsed_username = parsed_jwt["preferred_username"]
             except:
-                log.warning("Could not retrieve preferred_username from access token.")
+                log.warning("Could not retrieve 'preferred_username' from access token.")
 
             if parsed_username != None:
                 if self.username != None and self.username != parsed_username:


### PR DESCRIPTION
# Set username based on token

## Description
The username field is currently set when a client is instantiated. Due to different auth workflows, the username may not match the preferred username defined in the auth token. This PR attempts to adjust the username based on the auth token.

## Checklist
Please complete the following checklist before submitting your pull request:
- [x] I have tested these changes locally and verified that they work as intended.
- [x] I have updated any documentation as needed to reflect these changes (if appropriate)
- [x] I have verified that these changes to the best of my knowledge do not introduce any security vulnerabilities.
- [x] Unit tests have been added (if appropriate)
- [x] Test-cases have been added (if appropriate)
- [x] Testing instructions have been added (if appropriate)
