### PR TITLE
CI: update HPS services deployment

### DIFF
--- a/.github/actions/hps_services/action.yml
+++ b/.github/actions/hps_services/action.yml
@@ -1,0 +1,103 @@
+name: 'Local HPS Deployment'
+
+description: 'Docker Compose-based local HPS deployment'
+
+inputs:
+  
+  version:
+    description: 'HPS version'
+    required: true
+
+  token:
+    description: 'Token'
+    required: true
+
+  ghcr-username:
+    description: 'Username to access the ansys-internal github docker registry'
+    required: true
+  
+  ghcr-token:
+    description: 'Token to access the ansys-internal github docker registry'
+    required: true
+
+outputs:
+  url:
+    description: 'HPS URL'
+    value: ${{ steps.set-outputs.outputs.url }}
+
+  path:
+    description: 'Path of the docker compose artifact'
+    value: ${{ steps.set-outputs.outputs.path }}
+  
+runs:
+  using: "composite"
+  
+  steps:
+    - if: ${{ inputs.version != 'latest-dev' }}
+      uses: dsaltares/fetch-gh-release-asset@master
+      name: Download Customer Services Artifact
+      with:
+        file: 'docker-compose-customer.tar.gz'
+        target: 'docker-compose-artifact/docker-compose-customer.tar.gz'
+        repo: ansys-internal/rep-deployments
+        version: tags/${{ inputs.version }}
+        token: ${{ inputs.token }}
+
+    - if: ${{ inputs.version == 'latest-dev' }}
+      uses: dsaltares/fetch-gh-release-asset@master
+      name: Download Internal Services Artifact
+      with:
+        file: 'docker-compose-internal.tar.gz'
+        target: 'docker-compose-artifact/docker-compose-internal.tar.gz'
+        repo: ansys-internal/rep-deployments
+        version: tags/v1.0.3
+        token: ${{ inputs.token }}
+
+    - uses: KengoTODA/actions-setup-docker-compose@main
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+
+    - name: Login in Github Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.ghcr-username }}
+        password: ${{ inputs.ghcr-token }}
+
+    - name: Start services (customer package)
+      if: ${{ inputs.version != 'latest-dev' }}
+      shell: bash
+      run: |
+        ls -la
+        tar -xvzf docker-compose-customer.tar.gz
+        mv docker-compose-customer docker-compose
+        cd docker-compose
+        docker-compose build
+        docker-compose up -d
+      working-directory: ./docker-compose-artifact
+
+    - name: Start services (internal package)
+      if: ${{ inputs.version == 'latest-dev' }}
+      shell: bash
+      run: |
+        ls -la
+        tar -xvzf docker-compose-internal.tar.gz
+        cd docker-compose
+        FSGATEWAY_TAG=latest-dev JMS_TAG=latest-dev docker-compose pull
+        FSGATEWAY_TAG=latest-dev JMS_TAG=latest-dev docker-compose up -d
+      working-directory: ./docker-compose-artifact
+
+    - name: Wait for services
+      shell: bash
+      run: |
+        curl -k --head -X GET --retry 30 --retry-connrefused --retry-delay 1 https://localhost:8443/hps/jms/api/v1
+        curl -k --head -X GET --retry 30 --retry-connrefused --retry-delay 1 https://localhost:8443/hps/fs/api/v1
+        curl -k --head -X GET --retry 30 --retry-connrefused --retry-delay 1 https://localhost:8443/hps/rms/api/v1
+
+    - name: Set outputs
+      id: set-outputs
+      shell: bash
+      run: |
+        echo "url=https://localhost:8443/hps" >> $GITHUB_OUTPUT
+        echo "path=$(pwd)" >> $GITHUB_OUTPUT
+      working-directory: ./docker-compose-artifact/docker-compose

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -4,8 +4,12 @@ on:
     inputs:
       hps-version:
         description: HPS version to test against
-        default: '1.0.2'
-        type: string
+        default: 'latest-dev'
+        type: choice
+        options:
+          - 'v1.0.2'
+          - 'v1.0.3'
+          - 'latest-dev'
 
   pull_request:
   push:
@@ -52,7 +56,7 @@ jobs:
       python-version: ${{ matrix.cfg.python-version }}   
       toxenv: ${{ matrix.cfg.toxenv }}
       runner: ${{ matrix.os }}
-      hps-version: v${{ inputs.hps-version || '1.0.2' }}
+      hps-version: ${{ inputs.hps-version || 'latest-dev' }}
 
   docs:
     name: Documentation

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,16 @@
 name: Nightly Build
 on:
   workflow_dispatch:
+    inputs:
+      hps-version:
+        description: HPS version to test against
+        default: 'latest-dev'
+        type: choice
+        options:
+          - 'v1.0.2'
+          - 'v1.0.3'
+          - 'latest-dev'
+
   schedule:
   - cron: "0 2 * * *"
 
@@ -55,7 +65,8 @@ jobs:
       python-version: ${{ matrix.cfg.python-version }}   
       toxenv: ${{ matrix.cfg.toxenv }}
       runner: ${{ matrix.os }}
-        
+      hps-version: ${{ inputs.hps-version || 'latest-dev' }}
+
   smoke-tests:
     name: Build and Smoke tests
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on:
       hps-version:
         description: HPS version to test against
         type: string
-        default: 'v1.0.2'
+        default: 'latest-dev'
 
 jobs:
 
@@ -36,42 +36,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools tox tox-gh-actions
           mkdir docker-compose-artifact
-
-      - uses: dsaltares/fetch-gh-release-asset@master
-        name: Download Services Artifact
-        with:
-          file: 'docker-compose-customer.tar.gz'
-          target: 'docker-compose-artifact/docker-compose-customer.tar.gz'
-          repo: ansys-internal/rep-deployments
-          version: tags/${{ inputs.hps-version }}
-          token: ${{secrets.PYANSYS_CI_BOT_TOKEN}}
-
-      - uses: KengoTODA/actions-setup-docker-compose@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Login in Github Container registry
-        uses: docker/login-action@v3
+      - name: Start HPS services
+        id: hps-services
+        uses: ./.github/actions/hps_services
         with:
-          registry: ghcr.io/ansys-internal
-          username: pyansys-ci-bot
-          password: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-
-      - name: Start services
-        run: |
-          ls -la
-          tar -xvzf docker-compose-customer.tar.gz
-          cd docker-compose-customer
-          docker-compose build
-          docker-compose up -d
-          echo "Waiting a few sec ..."
-          sleep 5
-        working-directory: ./docker-compose-artifact
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          ghcr-username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          ghcr-token: ${{ secrets.PYANSYS_CI_BOT_PACKAGE_TOKEN }}
+          version: ${{ inputs.hps-version }}
 
       - name: Test with tox
         run: tox -e ${{ inputs.toxenv }}-coverage
         env:
-          HPS_TEST_URL: https://localhost:8443/hps
+          HPS_TEST_URL: ${{ steps.hps-services.outputs.url }}
           HPS_TEST_USERNAME: repadmin
           HPS_TEST_PASSWORD: repadmin
 
@@ -103,9 +81,3 @@ jobs:
       - name: Publish services info to summary
         if: success() || failure()
         run: cat build_info.md >> $GITHUB_STEP_SUMMARY
-  
-      - name: Stop services
-        if: always()
-        run: |
-          docker-compose down -v
-        working-directory: ./docker-compose-artifact/docker-compose-customer


### PR DESCRIPTION
- Reworked the CI actions to support testing against docker compose internal deployment (latest-dev). 
- By default, on main we now run tests against the latest docker compose internal deployment. CI and nightly workflows can be manually triggered against a specific version 
   ![image](https://github.com/ansys/pyhps/assets/11756875/755fca5f-4e00-42ab-8c1b-613a0d735224)
   When selecting a vX.X.X version, we use the customer docker compose to start services.