### PR TITLE
Use request.Session() in a 'with' block

### DIFF
--- a/src/ansys/hps/client/authenticate.py
+++ b/src/ansys/hps/client/authenticate.py
@@ -92,32 +92,33 @@ def authenticate(
         auth_url = urllib.parse.urljoin(url + "/", auth_postfix)
     log.debug(f"Authenticating using {auth_url}")
 
-    session = requests.Session()
-    session.verify = verify
-    session.headers = ({"content-type": "application/x-www-form-urlencoded"},)
+    with requests.Session() as session:
+        session.verify = verify
+        session.headers = ({"content-type": "application/x-www-form-urlencoded"},)
 
-    token_url = f"{auth_url}/protocol/openid-connect/token"
+        token_url = f"{auth_url}/protocol/openid-connect/token"
 
-    data = {
-        "client_id": client_id,
-        "grant_type": grant_type,
-        "scope": scope,
-    }
-    if client_secret is not None:
-        data["client_secret"] = client_secret
-    if username is not None:
-        data["username"] = username
-    if password is not None:
-        data["password"] = password
-    if refresh_token is not None:
-        data["refresh_token"] = refresh_token
+        data = {
+            "client_id": client_id,
+            "grant_type": grant_type,
+            "scope": scope,
+        }
+        if client_secret is not None:
+            data["client_secret"] = client_secret
+        if username is not None:
+            data["username"] = username
+        if password is not None:
+            data["password"] = password
+        if refresh_token is not None:
+            data["refresh_token"] = refresh_token
 
-    data.update(**kwargs)
+        data.update(**kwargs)
 
-    log.debug(
-        f"Retrieving access token for client {client_id} from {auth_url} using {grant_type} grant."
-    )
-    r = session.post(token_url, data=data, timeout=timeout)
+        log.debug(
+            "Retrieving access token for client "
+            f"{client_id} from {auth_url} using {grant_type} grant."
+        )
+        r = session.post(token_url, data=data, timeout=timeout)
 
-    raise_for_status(r)
-    return r.json()
+        raise_for_status(r)
+        return r.json()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -126,7 +126,7 @@ def test_authentication_refresh_token(url, username, password):
     assert client.refresh_token is not None
 
     i = 0
-    num_iter = 10000
+    num_iter = 200000
     while i < num_iter:
 
         access_token = client.access_token

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -114,3 +114,31 @@ def test_authentication_username_exception(url, username, keycloak_client):
             client_id=rep_impersonation_client["clientId"],
             client_secret=rep_impersonation_client["secret"],
         )
+
+
+def test_authentication_refresh_token(url, username, password):
+
+    # realm_settings  = keycloak_client.get_realm("rep")
+    # realm_settings['accessTokenLifespan'] = 2  # token expiration in seconds
+
+    client = Client(url, username, password)
+    assert client.access_token is not None
+    assert client.refresh_token is not None
+
+    i = 0
+    num_iter = 10000
+    while i < num_iter:
+
+        access_token = client.access_token
+        refresh_token = client.refresh_token
+
+        # wait a moment otherwise the OAuth server will issue the very same tokens
+        time.sleep(0.1)
+
+        client.refresh_access_token()
+        assert client.access_token != access_token
+        assert client.refresh_token != refresh_token
+
+        i += 1
+        if i % (num_iter / 100) == 0:
+            log.info(f"Counter: {i}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -114,31 +114,3 @@ def test_authentication_username_exception(url, username, keycloak_client):
             client_id=rep_impersonation_client["clientId"],
             client_secret=rep_impersonation_client["secret"],
         )
-
-
-def test_authentication_refresh_token(url, username, password):
-
-    # realm_settings  = keycloak_client.get_realm("rep")
-    # realm_settings['accessTokenLifespan'] = 2  # token expiration in seconds
-
-    client = Client(url, username, password)
-    assert client.access_token is not None
-    assert client.refresh_token is not None
-
-    i = 0
-    num_iter = 10000
-    while i < num_iter:
-
-        access_token = client.access_token
-        refresh_token = client.refresh_token
-
-        # wait a moment otherwise the OAuth server will issue the very same tokens
-        time.sleep(0.1)
-
-        client.refresh_access_token()
-        assert client.access_token != access_token
-        assert client.refresh_token != refresh_token
-
-        i += 1
-        if i % (num_iter / 100) == 0:
-            log.info(f"Counter: {i}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -126,7 +126,7 @@ def test_authentication_refresh_token(url, username, password):
     assert client.refresh_token is not None
 
     i = 0
-    num_iter = 200000
+    num_iter = 10000
     while i < num_iter:
 
         access_token = client.access_token


### PR DESCRIPTION
## Description
 Without the 'with' block the count of open files go up on each authentication

Tested on pcluster comparing with scaler without the change.  open file count remained at 3500 after running over the weekend.  

## Checklist
- [x] I have tested these changes locally.
- [ ] I have added unit tests (if appropriate).
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have linked the issue(s) addressed by this PR if any.