### PR TITLE
fix: updated required ansys-sphinx-theme version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ tests = [
 ]
 
 doc = [
-    "ansys-sphinx-theme==1.0.7",
+    "ansys-sphinx-theme==1.2.1",
     "autodoc_pydantic==2.1.0",
     "jupyter_sphinx==0.5.3",
     "nbsphinx==0.9.5",


### PR DESCRIPTION
## Description
This PR fixes #490 and ansys-internal/pyansys-planning#96. 
[Examples](https://hps.docs.pyansys.com/version/stable/examples/ex_motorbike_frame.html#example-mapdl-motorbike-frame) in the stable version of pyhps documentation are not rendering properly. The cause of this behavior is the old ansys-sphinx-theme version that was in use when the stable version of the doc was deployed, and updating to the latest version fixes the issue. A v0.9.1 patch release is therefore recommended.

## Checklist
- [x] I have tested these changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.