### PR TITLE
[CI-CD]: Introduce profile input for docker-compose in testing

### DIFF
--- a/.github/actions/hps_services/action.yml
+++ b/.github/actions/hps_services/action.yml
@@ -99,7 +99,11 @@ runs:
         tar -xvzf docker-compose-internal.tar.gz
         cd docker-compose
         docker-compose pull
-        docker-compose --profile $PROFILE up -d
+        if [ -z "$PROFILE"]; then
+          docker-compose up -d
+        else
+          docker-compose --profile $PROFILE up -d
+        fi        
       working-directory: ./docker-compose-artifact
 
     - name: Wait for services

--- a/.github/actions/hps_services/action.yml
+++ b/.github/actions/hps_services/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Token to access the ansys-internal github docker registry'
     required: true
 
+  profile:
+    description: 'Docker compose profiles to use'
+    required: false
+
 outputs:
   url:
     description: 'HPS URL'
@@ -85,6 +89,8 @@ runs:
 
     - name: Start services (internal package)
       if: ${{ inputs.version == 'latest-dev' }}
+      env:
+        PROFILE: ${{ inputs.profile }}
       shell: bash
       run: |
         echo "$(pwd)"
@@ -93,7 +99,7 @@ runs:
         tar -xvzf docker-compose-internal.tar.gz
         cd docker-compose
         docker-compose pull
-        docker-compose up -d
+        docker-compose --profile $PROFILE up -d
       working-directory: ./docker-compose-artifact
 
     - name: Wait for services

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,10 @@ on:
         description: HPS Feature to test against (only for latest-dev version)
         type: string
         default: 'main'
+      docker-compose-profiles:
+        description: Docker compose profiles to use
+        type: string
+        default: 'stable,data-transfer-minio'
 
 jobs:
 
@@ -56,6 +60,7 @@ jobs:
           ghcr-token: ${{ secrets.PYANSYS_CI_BOT_PACKAGE_TOKEN }}
           version: ${{ inputs.hps-version }}
           feature: ${{ inputs.hps-feature }}
+          profile: ${{ inputs.docker-compose-profiles }}
    
       - name: Test with tox
         run: tox -e ${{ inputs.toxenv }}-coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ on:
       docker-compose-profiles:
         description: Docker compose profiles to use
         type: string
-        default: 'stable,data-transfer-minio'
 
 jobs:
 
@@ -53,7 +52,7 @@ jobs:
       
       - name: Start HPS services
         id: hps-services
-        uses: ansys/pyhps/.github/actions/hps_services@main
+        uses: ansys/pyhps/.github/actions/hps_services@mguntupa/workflow
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           ghcr-username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       
       - name: Start HPS services
         id: hps-services
-        uses: ansys/pyhps/.github/actions/hps_services@mguntupa/workflow
+        uses: ansys/pyhps/.github/actions/hps_services@main
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           ghcr-username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}


### PR DESCRIPTION
## Description
CI-CD passed: https://github.com/ansys/pyhps/actions/runs/13859909138
Introducing "profile" input to pass it to docker-compose. The test workflow is being re-used in dt_client repo and this input will help pass the profile "backend" which will only launch necessary services for testing.
Default is emplty which means docker-compose will use the profile from .env file which is the default behaviour. 
Related PR in rep-deployments: https://github.com/ansys-internal/rep-deployments/pull/389 

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.