### PR TITLE
Update services action and versions input

### DIFF
--- a/.github/actions/hps_services/action.yml
+++ b/.github/actions/hps_services/action.yml
@@ -109,9 +109,10 @@ runs:
     - name: Wait for services
       shell: bash
       run: |
-        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 10 -O- https://localhost:8443/hps/jms/api/v1
-        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 10 -O- https://localhost:8443/hps/fs/api/v1
-        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 10 -O- https://localhost:8443/hps/rms/api/v1
+        # retry each service max 15 times
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 15 -O- https://localhost:8443/hps/jms/api/v1
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 15 -O- https://localhost:8443/hps/fs/api/v1
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 15 -O- https://localhost:8443/hps/rms/api/v1
 
     - name: Set outputs
       id: set-outputs

--- a/.github/actions/hps_services/action.yml
+++ b/.github/actions/hps_services/action.yml
@@ -109,10 +109,10 @@ runs:
     - name: Wait for services
       shell: bash
       run: |
-        # retry each service max 15 times
-        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 15 -O- https://localhost:8443/hps/jms/api/v1
-        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 15 -O- https://localhost:8443/hps/fs/api/v1
-        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 15 -O- https://localhost:8443/hps/rms/api/v1
+        # retry each service max 20 times
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 20 -O- https://localhost:8443/hps/jms/api/v1
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 20 -O- https://localhost:8443/hps/fs/api/v1
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 20 -O- https://localhost:8443/hps/rms/api/v1
 
     - name: Set outputs
       id: set-outputs

--- a/.github/actions/hps_services/action.yml
+++ b/.github/actions/hps_services/action.yml
@@ -109,9 +109,9 @@ runs:
     - name: Wait for services
       shell: bash
       run: |
-        curl -k --head -X GET --retry 30 --retry-connrefused --retry-delay 5 https://localhost:8443/hps/jms/api/v1
-        curl -k --head -X GET --retry 30 --retry-connrefused --retry-delay 1 https://localhost:8443/hps/fs/api/v1
-        curl -k --head -X GET --retry 30 --retry-connrefused --retry-delay 1 https://localhost:8443/hps/rms/api/v1
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 10 -O- https://localhost:8443/hps/jms/api/v1
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 10 -O- https://localhost:8443/hps/fs/api/v1
+        wget --retry-connrefused --retry-on-http-error=503,404 --no-check-certificate -t 10 -O- https://localhost:8443/hps/rms/api/v1
 
     - name: Set outputs
       id: set-outputs

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -56,7 +56,7 @@ jobs:
       python-version: ${{ matrix.cfg.python-version }}   
       toxenv: ${{ matrix.cfg.toxenv }}
       runner: ${{ matrix.os }}
-      hps-version: ${{ inputs.hps-version || 'latest-dev' }}
+      hps-version: ${{ inputs.hps-version || 'v1.2.0' }}
       hps-feature: ${{ inputs.hps-feature || 'main' }}
 
   docs:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       hps-version:
         description: HPS version to test against
-        default: 'latest-dev'
+        default: 'v1.2.0'
         type: choice
         options:
           - 'v1.0.2'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -56,7 +56,7 @@ jobs:
       python-version: ${{ matrix.cfg.python-version }}   
       toxenv: ${{ matrix.cfg.toxenv }}
       runner: ${{ matrix.os }}
-      hps-version: ${{ inputs.hps-version || 'v1.2.0' }}
+      hps-version: ${{ inputs.hps-version || 'latest-dev' }}
       hps-feature: ${{ inputs.hps-feature || 'main' }}
 
   docs:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       hps-version:
         description: HPS version to test against
-        default: 'v1.2.0'
+        default: 'latest-dev'
         type: choice
         options:
           - 'v1.0.2'
@@ -56,7 +56,7 @@ jobs:
       python-version: ${{ matrix.cfg.python-version }}   
       toxenv: ${{ matrix.cfg.toxenv }}
       runner: ${{ matrix.os }}
-      hps-version: ${{ inputs.hps-version || 'latest-dev' }}
+      hps-version: ${{ inputs.hps-version || 'v1.2.0' }}
       hps-feature: ${{ inputs.hps-feature || 'main' }}
 
   docs:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -8,7 +8,8 @@ on:
         type: choice
         options:
           - 'v1.0.2'
-          - 'v1.0.3'
+          - 'v1.1.1'
+          - 'v1.2.0'
           - 'latest-dev'
       hps-feature:
         description: HPS feature to test against

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
       python-version: ${{ matrix.cfg.python-version }}   
       toxenv: ${{ matrix.cfg.toxenv }}
       runner: ${{ matrix.os }}
-      hps-version: ${{ inputs.hps-version || 'latest-dev' }}
+      hps-version: ${{ inputs.hps-version || 'v1.2.0' }}
       
   smoke-tests:
     name: Build and Smoke tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,8 @@ on:
         type: choice
         options:
           - 'v1.0.2'
-          - 'v1.0.3'
+          - 'v1.1.1'
+          - 'v1.2.0'
           - 'latest-dev'
 
   schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       
       - name: Start HPS services
         id: hps-services
-        uses: ansys/pyhps/.github/actions/hps_services@maint/update-action
+        uses: ansys/pyhps/.github/actions/hps_services@main
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           ghcr-username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       
       - name: Start HPS services
         id: hps-services
-        uses: ansys/pyhps/.github/actions/hps_services@main
+        uses: ansys/pyhps/.github/actions/hps_services@maint/update-action
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           ghcr-username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: 85%
     patch: off
 
 


### PR DESCRIPTION
- Update action to start up services
- Update HPS version input options
- Test against HPS v1.2.0 as long as latest-dev is unstable
- Set test coverage target to 85% to temporarily avoid failures due to codecov changes