### PR TITLE
fix: remove "main" identifier - by default it pulls the "default" branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "backoff>=2.0.0",
     "pydantic>=1.10.0",
     "PyJWT>=2.8.0",
-    "ansys-hps-data-transfer-client@git+https://github.com/ansys/pyhps-data-transfer.git@main"
+    "ansys-hps-data-transfer-client@git+https://github.com/ansys/pyhps-data-transfer.git"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The ``@main`` part is not needed and prevents from installing packages from source together. I can show offline.