### PR TITLE
fix auth test to use proper url

### DIFF
--- a/src/ansys/hps/client/__init__.py
+++ b/src/ansys/hps/client/__init__.py
@@ -23,7 +23,7 @@
 
 from .__version__ import __ansys_apps_version__, __version__
 from .auth import AuthApi
-from .authenticate import authenticate
+from .authenticate import authenticate, determine_auth_url
 from .client import Client
 from .exceptions import APIError, ClientError, HPSError
 from .jms import JmsApi, ProjectApi

--- a/tests/auth/test_api.py
+++ b/tests/auth/test_api.py
@@ -132,10 +132,10 @@ def test_impersonate_user(url, keycloak_client):
     r = None
     try:
         r = authenticate(
-            url=url,
+            auth_url=client.auth_url,
             client_id=rep_impersonation_client["clientId"],
             client_secret=rep_impersonation_client["secret"],
-            scope="opendid offline_access",
+            scope="openid offline_access",
             grant_type="urn:ietf:params:oauth:grant-type:token-exchange",
             subject_token=client.access_token,
             requested_token_type="urn:ietf:params:oauth:token-type:refresh_token",

--- a/tests/auth/test_authenticate.py
+++ b/tests/auth/test_authenticate.py
@@ -21,29 +21,97 @@
 # SOFTWARE.
 
 import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 
-from ansys.hps.client import Client, authenticate
+from ansys.hps.client import authenticate, determine_auth_url
 
 log = logging.getLogger(__name__)
 
 
 def test_authenticate(url, username, password):
-    client = Client(url=url, username=username, password=password, verify=False)
-    resp = authenticate(
-        auth_url=client.auth_url, username=username, password=password, verify=False
-    )
+    auth_url = determine_auth_url(hps_url=url, verify_ssl=False, fallback_realm="rep")
+    resp = authenticate(auth_url=auth_url, username=username, password=password, verify=False)
 
     assert "access_token" in resp
     assert "refresh_token" in resp
 
 
-def test_authenticate_with_ssl_verification(url, username, password):
-    # Doesn't matter that the auth url is wrong....  The first request will fail
+def test_determine_auth_url_with_ssl_verification(url):
     with pytest.raises(requests.exceptions.SSLError) as ex_info:
-        _ = authenticate(
-            auth_url=f"{url}/auth/realms/rep", username=username, password=password, verify=True
-        )
+        determine_auth_url(hps_url=url, verify_ssl=True, fallback_realm="rep")
     assert "CERTIFICATE_VERIFY_FAILED" in str(ex_info.value)
+
+
+def test_authenticate_with_ssl_verification(url, username, password):
+    auth_url = determine_auth_url(hps_url=url, verify_ssl=False, fallback_realm="rep")
+    with pytest.raises(requests.exceptions.SSLError) as ex_info:
+        _ = authenticate(auth_url=auth_url, username=username, password=password, verify=True)
+    assert "CERTIFICATE_VERIFY_FAILED" in str(ex_info.value)
+
+
+def test_determine_auth_url_success():
+    hps_url = "https://example.com"
+    verify_ssl = False
+    fallback_realm = "rep"
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "services": {"external_auth_url": "https://auth.example.com"}
+    }
+
+    with patch("requests.Session.get", return_value=mock_response):
+        auth_url = determine_auth_url(hps_url, verify_ssl, fallback_realm)
+        assert auth_url == "https://auth.example.com"
+
+
+def test_determine_auth_url_fallback_realm():
+    hps_url = "https://example.com"
+    verify_ssl = False
+    fallback_realm = "rep"
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+
+    with patch("requests.Session.get", return_value=mock_response):
+        auth_url = determine_auth_url(hps_url, verify_ssl, fallback_realm)
+        assert auth_url == f"{hps_url.rstrip('/')}/auth/realms/{fallback_realm}"
+
+
+def test_determine_auth_url_no_realm():
+    hps_url = "https://example.com"
+    verify_ssl = False
+    fallback_realm = None
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {}
+
+    with (
+        patch("requests.Session.get", return_value=mock_response),
+        patch("logging.Logger.warning") as mock_warning,
+    ):
+        auth_url = determine_auth_url(hps_url, verify_ssl, fallback_realm)
+        assert auth_url is None
+        mock_warning.assert_called_once_with(
+            "External_auth_url not found from JMS and no realm specified."
+        )
+
+
+def test_determine_auth_url_failure():
+    hps_url = "https://example.com"
+    verify_ssl = False
+    fallback_realm = "rep"
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.content.decode.return_value = "Internal Server Error"
+
+    with (
+        patch("requests.Session.get", return_value=mock_response),
+        pytest.raises(RuntimeError) as ex_info,
+    ):
+        determine_auth_url(hps_url, verify_ssl, fallback_realm)
+    assert "Failed to contact jms info endpoint" in str(ex_info.value)
+    assert "status code 500" in str(ex_info.value)
+    assert "Internal Server Error" in str(ex_info.value)


### PR DESCRIPTION
## Description
The parameter is actually "auth_url" not "url" and url was getting passed through as a "special kwarg" to the post command, which is not what is desired.

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have linked the issue(s) addressed by this PR if any.