### PR TITLE
Dont ever assume the path from the HPS url, always work from the auth_url

### DIFF
--- a/src/ansys/hps/client/auth/api/auth_api.py
+++ b/src/ansys/hps/client/auth/api/auth_api.py
@@ -63,7 +63,7 @@ class AuthApi:
     def realm_url(self) -> str:
         """Realm URL."""
         # return f"{self.url}/admin/realms/{self.client.realm}"
-        return f"{self.client.auth_url}".replace("/auth/realms", "/admin/realms")
+        return f"{self.client.auth_url}".replace("/auth/realms", "/auth/admin/realms")
 
     def get_users(self, as_objects=True, **query_params) -> list[User]:
         """Get users, filtered according to query parameters.

--- a/src/ansys/hps/client/auth/api/auth_api.py
+++ b/src/ansys/hps/client/auth/api/auth_api.py
@@ -56,12 +56,12 @@ class AuthApi:
     @property
     def url(self) -> str:
         """API URL."""
-        return f"{self.client.url}/auth"
+        return f"{self.client.auth_api_url}"
 
     @property
     def realm_url(self) -> str:
         """Realm URL."""
-        return f"{self.url}/admin/realms/{self.client.realm}"
+        return f"{self.client.auth_url}"
 
     def get_users(self, as_objects=True, **query_params) -> list[User]:
         """Get users, filtered according to query parameters.

--- a/src/ansys/hps/client/auth/api/auth_api.py
+++ b/src/ansys/hps/client/auth/api/auth_api.py
@@ -56,12 +56,14 @@ class AuthApi:
     @property
     def url(self) -> str:
         """API URL."""
-        return f"{self.client.auth_api_url}"
+        # return f"{self.client.url}/auth"
+        return f"{self.client.auth_api_url}".rstrip("/")
 
     @property
     def realm_url(self) -> str:
         """Realm URL."""
-        return f"{self.client.auth_url}"
+        # return f"{self.url}/admin/realms/{self.client.realm}"
+        return f"{self.client.auth_url}".replace("/auth/realms", "/admin/realms")
 
     def get_users(self, as_objects=True, **query_params) -> list[User]:
         """Get users, filtered according to query parameters.

--- a/src/ansys/hps/client/auth/api/auth_api.py
+++ b/src/ansys/hps/client/auth/api/auth_api.py
@@ -56,13 +56,11 @@ class AuthApi:
     @property
     def url(self) -> str:
         """API URL."""
-        # return f"{self.client.url}/auth"
         return f"{self.client.auth_api_url}".rstrip("/")
 
     @property
     def realm_url(self) -> str:
         """Realm URL."""
-        # return f"{self.url}/admin/realms/{self.client.realm}"
         return f"{self.client.auth_url}".replace("/auth/realms", "/auth/admin/realms")
 
     def get_users(self, as_objects=True, **query_params) -> list[User]:

--- a/tests/auth/test_api.py
+++ b/tests/auth/test_api.py
@@ -22,6 +22,7 @@
 
 import logging
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 from keycloak import KeycloakOpenID
@@ -184,3 +185,25 @@ def test_impersonate_user(url, keycloak_client):
     assert token_info["preferred_username"] == new_user.username
 
     delete_user(keycloak_client, new_user)
+
+
+def test_auth_api_url(client):
+    """Test that the auth_api_url property returns the
+    correct URL for the default instance of JMS."""
+    api = AuthApi(client)
+    auth_api_url = client.auth_api_url.rstrip("/")
+    assert api.realm_url == f"{auth_api_url}/admin/realms/{client.realm}"
+    assert api.url == auth_api_url
+
+
+def test_customized_auth_api_url(client):
+    """Test that the auth_api_url property returns the correct URL for custom entries."""
+    # Mock the client object so we can easily force a specific URL that's not the default
+    mock_client = MagicMock()
+    mock_client.auth_url = "https://example.com/dev/hps/auth/realms/myrealm"
+
+    # Create an instance of AuthApi with the mocked client
+    auth_api = AuthApi(client=mock_client)
+
+    # Assert the expected transformation
+    assert auth_api.realm_url == "https://example.com/dev/hps/auth/admin/realms/myrealm"


### PR DESCRIPTION
## Description
When supporting the use case for Fuji, we are using impersonation with a different keycloak location, we need to avoid assuming that its in a static location next to other HPS services.

https://github.com/ansys-internal/rep-scaling/issues/718

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.