### PR TITLE
Maint/tox

### DIFF
--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -27,6 +27,7 @@ import logging
 import os
 import platform
 import warnings
+import tempfile
 
 import jwt
 import requests
@@ -317,6 +318,17 @@ class Client:
             company_folder = ".ansys"
 
         home_path = os.environ.get(environment_variable, None)
+        if home_path is None:
+            # Fallback to the temporary directory
+            log.error(
+                f"Environment variable {environment_variable} is not set. "
+                "Falling back to temporary directory."
+            )
+            home_path = tempfile.gettempdir()
+
+            log.info(
+                f"Using temporary directory {home_path} for data transfer binaries."
+            )
 
         return os.path.join(home_path, company_folder, "hps", "data-transfer", "binaries")
 

--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -26,8 +26,8 @@ import atexit
 import logging
 import os
 import platform
-import warnings
 import tempfile
+import warnings
 
 import jwt
 import requests
@@ -326,9 +326,7 @@ class Client:
             )
             home_path = tempfile.gettempdir()
 
-            log.info(
-                f"Using temporary directory {home_path} for data transfer binaries."
-            )
+            log.info(f"Using temporary directory {home_path} for data transfer binaries.")
 
         return os.path.join(home_path, company_folder, "hps", "data-transfer", "binaries")
 


### PR DESCRIPTION
## Description
Addressing https://github.com/ansys/pyhps/issues/647
LOCALAPPDATA is not set in tox. 
I found an older version with a similar issue: https://github.com/tox-dev/tox/issues/3151
Should we use a temporary directory instead? or fallback to it?

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.