### PR TITLE
Store refresh token if available when authenticating with access token

### DIFF
--- a/src/ansys/hps/client/client.py
+++ b/src/ansys/hps/client/client.py
@@ -188,6 +188,7 @@ class Client:
         if access_token:
             log.debug("Authenticate with access token")
             self.access_token = access_token
+            self.refresh_token = refresh_token
         else:
             if username and password:
                 self.grant_type = "password"


### PR DESCRIPTION
When passing both access and refresh token to the client object, we use the former for authentication and discard the latter. We should also store the latter to allow subsequent refreshes of the access token.  