### PR TITLE
Bump Traefik 3.3 version for compatibility with latest docker API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       
       - name: Start HPS services
         id: hps-services
-        uses: ansys/pyhps/.github/actions/hps_services@maint/fix-docker-traefik-issue
+        uses: ansys/pyhps/.github/actions/hps_services@main
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           ghcr-username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}


### PR DESCRIPTION
For HPS 1.3.45 Traefik is pinned at v3.3 which is incompatible with the latest Docker API. Patching the docker-compose file with v3.6.7 to be able to run backward compatibility tests.

See https://community.traefik.io/t/traefik-stops-working-it-uses-old-api-version-1-24/29019 and related issues.