### PR TITLE
[Doc] Add show source and edit on git at Home page

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -226,9 +226,18 @@ todo_include_todos = True
 
 html_theme = "ansys_sphinx_theme"
 
+html_context = {
+    "github_user": "ansys",
+    "github_repo": "ansys-sphinx-theme",
+    "github_version": "main",
+    "doc_path": "doc/source",
+    "pyansys_tags": ["Platform"],
+}
+
 # only for  sphinx_rtd_theme
 html_theme_options = {
     "github_url": "https://github.com/ansys/pyhps",
+    "use_edit_page_button": True,
     "show_prev_next": False,
     "show_breadcrumbs": True,
     "additional_breadcrumbs": [
@@ -258,9 +267,6 @@ html_favicon = ansys_favicon
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-
-# If true, links to the reST sources are added to the pages.
-html_show_sourcelink = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
@@ -442,7 +448,3 @@ def setup(app: sphinx.application.Sphinx) -> None:
 
     """
     app.connect("builder-inited", archive_examples)
-
-
-# PyAnsys tags configuration
-html_context = {"pyansys_tags": ["Platform"]}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -228,7 +228,7 @@ html_theme = "ansys_sphinx_theme"
 
 html_context = {
     "github_user": "ansys",
-    "github_repo": "ansys-sphinx-theme",
+    "github_repo": "pyhps",
     "github_version": "main",
     "doc_path": "doc/source",
     "pyansys_tags": ["Platform"],


### PR DESCRIPTION
## Description
Currently, the Doc seems to have a styling issue for the 0.12.0 release and the dev version 
<img width="1714" height="823" alt="image" src="https://github.com/user-attachments/assets/68b17b40-30a0-4952-9de3-2f0d62d805c9" />


The difference between the previous release doc (0.11.0) and the current is ansys-sphinx-theme.
If I look at the latest ansys-sphinx-theme doc page - the "Edit on github" button and "show source" button seems to put things in the right place. 
<img width="1912" height="978" alt="image" src="https://github.com/user-attachments/assets/72e8bead-7a63-44d2-8b3c-fe0608c2f16c" />

This PR makes sure we do the same to keep the styling in order (without needing to do any additional styling with css files)

This is how the home page looks after changes from this PR:
<img width="1875" height="1082" alt="image" src="https://github.com/user-attachments/assets/d14e1829-bc06-4823-902a-b944e500e759" />



## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.