### PR TITLE
Add Api info endpoint to RCS

### DIFF
--- a/examples/rcs_example.py
+++ b/examples/rcs_example.py
@@ -54,6 +54,8 @@ if __name__ == "__main__":
     )
     resp = rcs_api.health_check()
     log.info(f"RCS API health check: {resp}")
+    resp = rcs_api.get_api_info()
+    log.info(f"RCS API info: {resp}")
     log.info(f"Register instance with URL: {args.instance_url}")
     register_instance = rcs_api.register_instance(request_data)
     log.info(f"Register instance response: {register_instance}")

--- a/src/ansys/hps/client/rcs/api/rcs_api.py
+++ b/src/ansys/hps/client/rcs/api/rcs_api.py
@@ -51,6 +51,7 @@ class RcsApi:
         """Initialize the ``RmsApi`` object."""
         self.client = client
         self._health_check = None
+        self._api_info = None
         # Perform the health check during initialization
         if not self.health:
             raise ClientError("The RCS API is not alive. Cannot initialize RcsApi.")
@@ -71,6 +72,21 @@ class RcsApi:
     def health(self) -> bool:
         """Health status of the RCS API."""
         return self.health_check().get("status") == "alive"
+
+    def get_api_info(self):
+        """Get information on the RMS API the client is connected to.
+
+        The information includes the version and build date.
+        """
+        if self._api_info is None:
+            r = self.client.session.get(f"{self.url}/api/v1")
+            self._api_info = r.json()
+        return self._api_info
+
+    @property
+    def version(self) -> str:
+        """API version."""
+        return self.get_api_info()["build"]["version"]
 
     ################################################################
     # register instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,3 +152,8 @@ def has_hps_version_le_1_3_45(jms_api) -> bool:
 @pytest.fixture
 def has_hps_version_gt_1_3_45(jms_api) -> bool:
     return not check_max_version(jms_api.version, JMS_VERSIONS[HpsRelease.v1_3_45])
+
+
+@pytest.fixture
+def has_hps_version_gt_1_4_10(jms_api) -> bool:
+    return not check_max_version(jms_api.version, JMS_VERSIONS[HpsRelease.v1_4_10])

--- a/tests/rcs/test_api.py
+++ b/tests/rcs/test_api.py
@@ -85,10 +85,10 @@ def test_health_check(client, has_hps_version_le_1_3_45):
     assert response["status"] == "alive"
 
 
-def test_rcs_api_info(client, has_hps_version_le_1_3_45):
+def test_rcs_api_info(client, has_hps_version_gt_1_4_10):
     """Test the get_api_info method and the version property."""
-    if has_hps_version_le_1_3_45:
-        pytest.skip("RCS was introduced after HPS v1.3.45.")
+    if has_hps_version_gt_1_4_10:
+        pytest.skip("RCS api info was introduced after HPS v1.4.10.")
     rcs_api = RcsApi(client)
 
     assert rcs_api._api_info is None

--- a/tests/rcs/test_api.py
+++ b/tests/rcs/test_api.py
@@ -85,7 +85,10 @@ def test_health_check(client, has_hps_version_le_1_3_45):
     assert response["status"] == "alive"
 
 
-def test_rcs_api_info(client):
+def test_rcs_api_info(client, has_hps_version_le_1_3_45):
+    """Test the get_api_info method and the version property."""
+    if has_hps_version_le_1_3_45:
+        pytest.skip("RCS was introduced after HPS v1.3.45.")
     rcs_api = RcsApi(client)
 
     assert rcs_api._api_info is None

--- a/tests/rcs/test_api.py
+++ b/tests/rcs/test_api.py
@@ -87,7 +87,7 @@ def test_health_check(client, has_hps_version_le_1_3_45):
 
 def test_rcs_api_info(client, has_hps_version_gt_1_4_10):
     """Test the get_api_info method and the version property."""
-    if has_hps_version_gt_1_4_10:
+    if not has_hps_version_gt_1_4_10:
         pytest.skip("RCS api info was introduced after HPS v1.4.10.")
     rcs_api = RcsApi(client)
 

--- a/tests/rcs/test_api.py
+++ b/tests/rcs/test_api.py
@@ -85,6 +85,19 @@ def test_health_check(client, has_hps_version_le_1_3_45):
     assert response["status"] == "alive"
 
 
+def test_rcs_api_info(client):
+    rcs_api = RcsApi(client)
+
+    assert rcs_api._api_info is None
+
+    info = rcs_api.get_api_info()
+    assert "time" in info
+    assert "build" in info
+
+    assert rcs_api._api_info is not None
+    assert rcs_api.version is not None
+
+
 def test_register_instance_and_response(client, http_server, has_hps_version_le_1_3_45):
     """Test the register_instance and unregister_instance methods and their responses."""
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -27,6 +27,7 @@ import pytest
 
 from ansys.hps.client import Client
 from ansys.hps.client.jms import JmsApi
+from ansys.hps.client.rcs import RcsApi
 from ansys.hps.client.rms import RmsApi
 
 log = logging.getLogger(__name__)
@@ -60,7 +61,14 @@ def test_services(client: Client, build_info_path: str):
     assert "build" in rms_info
     assert "version" in rms_info["build"]
 
-    info = {"jms": jms_info, "dt": dt_info, "rms": rms_info}
+    # check rcs api
+    rcs_api = RcsApi(client)
+    rcs_info = rcs_api.get_api_info()
+    log.info(f"RCS api info\n{json.dumps(rcs_info, indent=2)}")
+    assert "build" in rcs_info
+    assert "version" in rcs_info["build"]
+
+    info = {"jms": jms_info, "dt": dt_info, "rms": rms_info, "rcs": rcs_info}
     with open(build_info_path, "w") as f:
         f.write(json.dumps(info, indent=2))
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -61,7 +61,7 @@ def test_services(client: Client, build_info_path: str, has_hps_version_gt_1_4_1
     assert "build" in rms_info
     assert "version" in rms_info["build"]
 
-    if not has_hps_version_gt_1_4_10:
+    if has_hps_version_gt_1_4_10:
         # check rcs api
         rcs_api = RcsApi(client)
         rcs_info = rcs_api.get_api_info()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.order(1)
-def test_services(client: Client, build_info_path: str, has_hps_version_le_1_3_45):
+def test_services(client: Client, build_info_path: str, has_hps_version_gt_1_4_10):
     # make sure services are up and running, print info
 
     # check jms api
@@ -61,7 +61,7 @@ def test_services(client: Client, build_info_path: str, has_hps_version_le_1_3_4
     assert "build" in rms_info
     assert "version" in rms_info["build"]
 
-    if not has_hps_version_le_1_3_45:
+    if not has_hps_version_gt_1_4_10:
         # check rcs api
         rcs_api = RcsApi(client)
         rcs_info = rcs_api.get_api_info()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.order(1)
-def test_services(client: Client, build_info_path: str):
+def test_services(client: Client, build_info_path: str, has_hps_version_le_1_3_45):
     # make sure services are up and running, print info
 
     # check jms api
@@ -61,14 +61,17 @@ def test_services(client: Client, build_info_path: str):
     assert "build" in rms_info
     assert "version" in rms_info["build"]
 
-    # check rcs api
-    rcs_api = RcsApi(client)
-    rcs_info = rcs_api.get_api_info()
-    log.info(f"RCS api info\n{json.dumps(rcs_info, indent=2)}")
-    assert "build" in rcs_info
-    assert "version" in rcs_info["build"]
+    if not has_hps_version_le_1_3_45:
+        # check rcs api
+        rcs_api = RcsApi(client)
+        rcs_info = rcs_api.get_api_info()
+        log.info(f"RCS api info\n{json.dumps(rcs_info, indent=2)}")
+        assert "build" in rcs_info
+        assert "version" in rcs_info["build"]
 
-    info = {"jms": jms_info, "dt": dt_info, "rms": rms_info, "rcs": rcs_info}
+        info = {"jms": jms_info, "dt": dt_info, "rms": rms_info, "rcs": rcs_info}
+    else:
+        info = {"jms": jms_info, "dt": dt_info, "rms": rms_info}
     with open(build_info_path, "w") as f:
         f.write(json.dumps(info, indent=2))
 


### PR DESCRIPTION
## Description
Changes are in response to this: https://github.com/ansys-internal/rep-route-creation-service/pull/658

This pull request adds support for retrieving and testing API information from the RCS API. The main improvements include implementing a method to fetch RCS API version and build details, exposing the version as a property, and adding corresponding tests and usage examples.

## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.