### PR TITLE
[MAINTENANCE] Missing or outdated pypa/gh-action-pypi-publish action in ansys/pyhps

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -265,14 +265,22 @@ jobs:
     needs: [package]
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
     steps:
-      - name: Release to the public PyPI repository
-        uses: ansys/actions/release-pypi-public@v10.3.1
+      - name: "Download the library artifacts from build-library step"
+        uses: actions/download-artifact@v8
         with:
-          library-name: ${{ env.PACKAGE_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          name: ${{ env.PACKAGE_NAME }}-artifacts
+          path: ${{ env.PACKAGE_NAME }}-artifacts
+
+      - name: "Upload artifacts to PyPI using trusted publisher"
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          repository-url: "https://upload.pypi.org/legacy/"
+          print-hash: true
+          packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+          skip-existing: false
 
       - name: Release to GitHub
         uses: ansys/actions/release-github@v10.3.1

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -268,7 +268,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - name: "Download the library artifacts from build-library step"
+      - name: "Download the library artifacts from package step"
         uses: actions/download-artifact@v8
         with:
           name: ${{ env.PACKAGE_NAME }}-artifacts


### PR DESCRIPTION
## Description
Addressing: https://github.com/ansys/pyhps/issues/634
Also: https://github.com/ansys/pyhps/issues/635
And: https://github.com/ansys/pyhps/issues/756

Do we still keep release to github step? it is not mentioned here: https://actions.docs.ansys.com/version/stable/migrations/release-pypi-trusted-publisher.html
## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.