### PR TITLE
Nightly: Add job-level permissions to style

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,8 @@ jobs:
               { python-version: '3.14', toxenv: 'py314' },
             ]
       fail-fast: false
+    permissions:
+      contents: read
     uses: ./.github/workflows/tests.yml
     secrets:
       PYANSYS_CI_BOT_PACKAGE_TOKEN: ${{ secrets.PYANSYS_CI_BOT_PACKAGE_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,8 @@ permissions: {}
 jobs:
 
   style:
+    permissions:
+      contents: read
     uses: ./.github/workflows/style.yml
 
   tests:


### PR DESCRIPTION
## Description
Nightly is failing due to recent changes:
https://github.com/ansys/pyhps/actions/runs/27321144681

[nightly.yml](vscode-file://vscode-app/c:/Users/mguntupa/AppData/Local/Programs/Microsoft%20VS%20Code/1b50d58d73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) has top-level permissions: {}, which means every job starts with contents: none.
Your reusable workflow [style.yml](vscode-file://vscode-app/c:/Users/mguntupa/AppData/Local/Programs/Microsoft%20VS%20Code/1b50d58d73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) contains jobs style and doc-style that require contents: read, so GitHub rejects the call unless the caller job grants it.

This PR fixes the issue:
https://github.com/ansys/pyhps/actions/runs/27355995606
## Checklist
- [x] I have tested these changes locally.
- [x] I have added unit tests (if appropriate).
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have linked the issue(s) addressed by this PR if any.